### PR TITLE
docs(contrib): add cross-reference to documentation architecture (TAS-286)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,8 @@
 # Tasker Contrib Documentation
 
+> Consumer-facing documentation is published in [The Tasker Book](https://github.com/tasker-systems/tasker-book).
+> See the [Documentation Architecture](https://github.com/tasker-systems/tasker-book/blob/main/DOCUMENTATION-ARCHITECTURE.md) for the cross-repo ownership model.
+
 ## Quick Links
 
 | Document | Description |


### PR DESCRIPTION
## Summary

- Adds front-matter note to `docs/README.md` pointing readers to The Tasker Book and the cross-repo DOCUMENTATION-ARCHITECTURE.md ownership model

Companion PRs: tasker-systems/book#9, tasker-systems/tasker-core#246

## Test plan

- [x] Single documentation change — no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)